### PR TITLE
Removed invalid child_process module from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "dependencies": {
         "assert": "~1.4.1", 
         "body-parser": "~1.15.2", 
-        "child_process": "~1.0.2", 
         "cookie-parser": "~1.4.3", 
         "express": "~4.14.0", 
         "express-session": "~1.14.1", 


### PR DESCRIPTION
Node's `require` function will always require internal `child_process` module, so importing ([inactive](https://www.npmjs.com/package/child_process)) user module `child_process` will always require builtin.

Relevant documentation: 
https://nodejs.org/api/modules.html
https://nodejs.org/api/child_process.html
